### PR TITLE
add --mavlink_gcs_udp_port param to the drone spawner

### DIFF
--- a/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink_gcs
+++ b/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink_gcs
@@ -1,0 +1,16 @@
+#!/bin/sh
+# shellcheck disable=SC2154
+
+# GCS link
+mavlink start -x -u $MAVLINK_GCS_UDP_PORT -r 4000000 -f
+mavlink stream -r 100 -s ATTITUDE -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 100 -s ATTITUDE_QUATERNION -u $MAVLINK_GCS_UDP_PORT # /mavros/imu/data
+mavlink stream -r 100 -s ATTITUDE_TARGET -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 100 -s HIGHRES_IMU -u $MAVLINK_GCS_UDP_PORT # /mavros/imu/data_raw
+mavlink stream -r 100 -s LOCAL_POSITION_NED -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 100 -s ODOMETRY -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 100 -s GLOBAL_POSITION_INT -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 10 -s RC_CHANNELS -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 10 -s SYS_STATUS -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 100 -s HEARTBEAT -u $MAVLINK_GCS_UDP_PORT
+mavlink stream -r 100 -s DISTANCE_SENSOR -u $MAVLINK_GCS_UDP_PORT

--- a/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d-posix/rcS
+++ b/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d-posix/rcS
@@ -271,6 +271,11 @@ fi
 #user defined mavlink streams for instances can be in PATH
 . px4-rc.mavlink
 
+if [ -n "$MAVLINK_GCS_UDP_PORT" ]
+then
+  . px4-rc.mavlink_gcs
+fi
+
 # execute autostart post script if any
 [ -e "$autostart_file".post ] && . "$autostart_file".post
 

--- a/ros_packages/mrs_uav_gazebo_simulation/launch/run_simulation_firmware.launch
+++ b/ros_packages/mrs_uav_gazebo_simulation/launch/run_simulation_firmware.launch
@@ -4,8 +4,9 @@
   <arg name="ID"/>
   <arg name="PX4_SIM_MODEL"/>
   <arg name="PX4_ESTIMATOR" default="ekf2"/>
+  <arg name="MAVLINK_GCS_UDP_PORT" default=""/> <!-- mavlink port for QGC -->
   <arg name="ROMFS_PATH" default="$(find mrs_uav_gazebo_simulation)/ROMFS"/>
-  
+
   <!-- PX4 configs -->
   <arg name="interactive" default="false"/>
   <!-- PX4 SITL -->
@@ -18,9 +19,10 @@
     <!-- PX4 params -->
     <env name="PX4_SIM_MODEL" value="$(arg PX4_SIM_MODEL)" />
     <env name="PX4_ESTIMATOR" value="$(arg PX4_ESTIMATOR)" />
+    <env if="$(eval MAVLINK_GCS_UDP_PORT != '')" name="MAVLINK_GCS_UDP_PORT" value="$(arg MAVLINK_GCS_UDP_PORT)" />
 
     <!-- PX4 SITL -->
     <node name="sitl_uav$(arg ID)" pkg="px4" type="px4" output="screen" args="$(arg ROMFS_PATH)/px4fmu_common -s etc/init.d-posix/rcS $(arg px4_interactive_mode) -i $(arg ID) -w sitl_uav$(arg ID)"/>
-  
+
   </group>
 </launch>

--- a/ros_packages/mrs_uav_gazebo_simulation/scripts/mrs_drone_spawner/mrs_drone_spawner.py
+++ b/ros_packages/mrs_uav_gazebo_simulation/scripts/mrs_drone_spawner/mrs_drone_spawner.py
@@ -471,7 +471,7 @@ class MrsDroneSpawner:
             'model': None,
             'ids': [],
             'names': [],
-            'spawn_poses': {},
+            'spawn_poses': {}
         }
 
         # parse out the keywords starting with '--'
@@ -999,6 +999,10 @@ class MrsDroneSpawner:
 
         robot_params['mavlink_config'] = self.get_mavlink_config_for_robot(ID)
 
+        if 'mavlink_gcs_udp_port' in params_dict.keys():
+            if len(params_dict['mavlink_gcs_udp_port']) > index:
+                robot_params['mavlink_gcs_udp_port'] = params_dict['mavlink_gcs_udp_port'][index]
+
         return robot_params
     # #}
 
@@ -1051,6 +1055,14 @@ class MrsDroneSpawner:
             'PX4_SIM_MODEL:=' + str(robot_params['model']),
             'ROMFS_PATH:=' + str(romfs_path)
         ]
+
+        # do we want to send raw mavlink data to a specific port? (this will also auto connect to QGroundControl)
+        if 'mavlink_gcs_udp_port' in robot_params.keys():
+            if isinstance(robot_params['mavlink_gcs_udp_port'], int):
+                roslaunch_args.append('MAVLINK_GCS_UDP_PORT:=' + str(robot_params["mavlink_gcs_udp_port"]))
+            else:
+                raise CouldNotLaunch(f'\'{robot_params["mavlink_gcs_udp_port"]}\' is not a valid port number')
+
         roslaunch_sequence = [(self.px4_fimrware_launch_path, roslaunch_args)]
 
         firmware_process = roslaunch.parent.ROSLaunchParent(uuid, roslaunch_sequence)


### PR DESCRIPTION
I added a way to enable Mavlink UDP stream at an arbitrary port. This is currently disabled by default. When enabled, QGroundControl will autoconnect to the simulated px4 using this port.

Other means can also be used to read the raw mavlink data from the port.

Use `--mavlink_gcs_udp_port PORT_NUMBER` as a spawner argument. PX4 uses 18570 as a base port number, but an arbitrary value may be used.
When spawning N vehicles with a single command, use N port numbers as well, e.g.:
`rosservice call /mrs_drone_spawner/spawn "1 2 --x500 --mavlink_gcs_udp_port 18570 18590"`
  
**NOTE**: It is the user's responsibility to ensure the ports do not overlap with other programs!

Config of the new mavlink stream can be found [here](https://github.com/ctu-mrs/mrs_uav_gazebo_simulation/blob/mavlink_to_gcs/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d-posix/px4-rc.mavlink_gcs).
If you want to enable QGC connection by default, assign a default port number [here](https://github.com/ctu-mrs/mrs_uav_gazebo_simulation/blob/f1a064093df212bc4bfec521becad1d7778b3548/ros_packages/mrs_uav_gazebo_simulation/launch/run_simulation_firmware.launch#L7).
