### PR TITLE
Added a third person camera

### DIFF
--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
@@ -2951,6 +2951,61 @@ limitations under the License.
 {%- endmacro -%}
 <!--}-->
 
+{# third_person_camera_macro {--> #}
+{%- macro third_person_camera_macro(camera_name, parent_link, x, y, z, mount, spawner_args) -%}
+
+  {%- set spawner_keyword = 'enable-third-person-camera' -%}
+  {%- set spawner_description = 'Add a third person camera following the UAV mode [1920x1080 100hz], translated by (-2.5, 0, -5.0)' -%}
+  {%- set spawner_default_args = {'update_rate': 100, 'noise': 0.0} -%}
+
+  {%- if spawner_keyword in spawner_args.keys() -%}
+    {{ generic.handle_spawner_args(spawner_keyword, spawner_default_args, spawner_args) }}
+
+    <!-- third person camera {-->
+
+    <!-- sensor {-->
+    {{ generic.camera_macro(
+      parent_link = parent_link,
+      camera_name = camera_name,
+      parent_frame_name = spawner_args['name'] + '/fcu',
+      camera_frame_name = spawner_args['name'] + '/' + camera_name + '_optical',
+      sensor_base_frame_name = spawner_args['name'] + '/' + camera_name,
+      frame_rate = spawner_args[spawner_keyword]['update_rate'],
+      horizontal_fov = 1.5,
+      image_width = 1920,
+      image_height = 1080,
+      min_distance = 0.02,
+      max_distance = 80,
+      noise_mean = 0.0,
+      noise_stddev = spawner_args[spawner_keyword]['noise'],
+      mesh_file = 'model://mrs_robots_description/meshes/sensors/bluefox.dae',
+      mesh_scale = '1 1 1',
+      color = 'Black',
+      visual_x = 0,
+      visual_y = 0,
+      visual_z = 0,
+      visual_roll = 0,
+      visual_pitch = 0,
+      visual_yaw = 0,
+      x = x,
+      y = y,
+      z = z,
+      roll = 0,
+      pitch = 0,
+      yaw = 0)
+    }}
+    <!--}-->
+
+    <!-- mount {-->
+    {{ mount if mount }}
+    <!--}-->
+
+    <!--}-->
+
+  {%- endif -%}
+{%- endmacro -%}
+{# <!--}--> #}
+
 {# ==================== Unsupported components ==================== #}
 
 {# TODO: not supported in the current version #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
@@ -2952,11 +2952,11 @@ limitations under the License.
 <!--}-->
 
 {# third_person_camera_macro {--> #}
-{%- macro third_person_camera_macro(camera_name, parent_link, x, y, z, mount, spawner_args) -%}
+{%- macro third_person_camera_macro(camera_name, parent_link, mount, spawner_args) -%}
 
   {%- set spawner_keyword = 'enable-third-person-camera' -%}
-  {%- set spawner_description = 'Add a third person camera following the UAV mode [1920x1080 100hz], translated by (-2.5, 0, -5.0)' -%}
-  {%- set spawner_default_args = {'update_rate': 100, 'noise': 0.0} -%}
+  {%- set spawner_description = 'Add a third person camera following the UAV mode [1920x1080 60hz]' -%}
+  {%- set spawner_default_args = {'update_rate': 60, 'noise_stddev': 0.0, 'x': '-1.5', 'y': '0.0', 'z': '0.5', 'hfov': 1.5} -%}
 
   {%- if spawner_keyword in spawner_args.keys() -%}
     {{ generic.handle_spawner_args(spawner_keyword, spawner_default_args, spawner_args) }}
@@ -2971,25 +2971,25 @@ limitations under the License.
       camera_frame_name = spawner_args['name'] + '/' + camera_name + '_optical',
       sensor_base_frame_name = spawner_args['name'] + '/' + camera_name,
       frame_rate = spawner_args[spawner_keyword]['update_rate'],
-      horizontal_fov = 1.5,
+      horizontal_fov = spawner_args[spawner_keyword]['hfov'],
       image_width = 1920,
       image_height = 1080,
       min_distance = 0.02,
       max_distance = 80,
       noise_mean = 0.0,
-      noise_stddev = spawner_args[spawner_keyword]['noise'],
+      noise_stddev = spawner_args[spawner_keyword]['noise_stddev'],
       mesh_file = 'model://mrs_robots_description/meshes/sensors/bluefox.dae',
       mesh_scale = '1 1 1',
       color = 'Black',
-      visual_x = 0,
-      visual_y = 0,
-      visual_z = 0,
+      visual_x = spawner_args[spawner_keyword]['x'],
+      visual_y = spawner_args[spawner_keyword]['y'],
+      visual_z = spawner_args[spawner_keyword]['z'],
       visual_roll = 0,
       visual_pitch = 0,
       visual_yaw = 0,
-      x = x,
-      y = y,
-      z = z,
+      x = spawner_args[spawner_keyword]['x'],
+      y = spawner_args[spawner_keyword]['y'],
+      z = spawner_args[spawner_keyword]['z'],
       roll = 0,
       pitch = 0,
       yaw = 0)

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
@@ -2956,7 +2956,7 @@ limitations under the License.
 
   {%- set spawner_keyword = 'enable-third-person-camera' -%}
   {%- set spawner_description = 'Add a third person camera following the UAV mode [1920x1080 60hz]' -%}
-  {%- set spawner_default_args = {'update_rate': 60, 'noise_stddev': 0.0, 'x': '-1.5', 'y': '0.0', 'z': '0.5', 'hfov': 1.5} -%}
+  {%- set spawner_default_args = {'update_rate': 60, 'noise_stddev': 0.0, 'x': '-1.5', 'y': '0.0', 'z': '0.5', 'hfov': 1.5, 'pitch': '0.32'} -%}
 
   {%- if spawner_keyword in spawner_args.keys() -%}
     {{ generic.handle_spawner_args(spawner_keyword, spawner_default_args, spawner_args) }}
@@ -2982,7 +2982,7 @@ limitations under the License.
       y = spawner_args[spawner_keyword]['y'],
       z = spawner_args[spawner_keyword]['z'],
       roll = 0,
-      pitch = 0,
+      pitch = spawner_args[spawner_keyword]['pitch'],
       yaw = 0)
     }}
     <!--}-->

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/component_snippets.sdf.jinja
@@ -2964,7 +2964,7 @@ limitations under the License.
     <!-- third person camera {-->
 
     <!-- sensor {-->
-    {{ generic.camera_macro(
+    {{ generic.camera_macro_meshless(
       parent_link = parent_link,
       camera_name = camera_name,
       parent_frame_name = spawner_args['name'] + '/fcu',
@@ -2978,15 +2978,6 @@ limitations under the License.
       max_distance = 80,
       noise_mean = 0.0,
       noise_stddev = spawner_args[spawner_keyword]['noise_stddev'],
-      mesh_file = 'model://mrs_robots_description/meshes/sensors/bluefox.dae',
-      mesh_scale = '1 1 1',
-      color = 'Black',
-      visual_x = spawner_args[spawner_keyword]['x'],
-      visual_y = spawner_args[spawner_keyword]['y'],
-      visual_z = spawner_args[spawner_keyword]['z'],
-      visual_roll = 0,
-      visual_pitch = 0,
-      visual_yaw = 0,
       x = spawner_args[spawner_keyword]['x'],
       y = spawner_args[spawner_keyword]['y'],
       z = spawner_args[spawner_keyword]['z'],

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/f330.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/f330.sdf.jinja
@@ -672,5 +672,15 @@
 
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
   </model>
 </sdf>

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/f450.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/f450.sdf.jinja
@@ -1115,6 +1115,16 @@
 
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
     {# ========================== other sensors ========================= #}
 
     {# Teraranger Tower Evo {--> #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/f550.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/f550.sdf.jinja
@@ -1201,6 +1201,16 @@
     }}
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
     {# ========================== other sensors ========================= #}
 
     {# Teraranger Tower Evo {--> #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/m690.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/m690.sdf.jinja
@@ -475,6 +475,16 @@
     }}
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
     {# TODO: this does not actually point down #}
     {# Basler down {--> #}
     {{ components.basler_camera_down_macro(

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/naki.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/naki.sdf.jinja
@@ -701,6 +701,16 @@
     }}
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
     {# ========================== other sensors ========================= #}
 
     {# Light {--> #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/robofly.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/robofly.sdf.jinja
@@ -389,6 +389,16 @@
 
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
   </model>
 
 </sdf>

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/t650.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/t650.sdf.jinja
@@ -925,6 +925,16 @@
     }}
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
+
     {# ========================== other sensors ========================= #}
 
     {# Teraranger Tower Evo {--> #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/x500.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/x500.sdf.jinja
@@ -940,6 +940,18 @@
     }}
     {# <!--}--> #}
 
+    {# third person camera {--> #}
+    {%- set third_person_camera = components.third_person_camera_macro(
+      camera_name = 'third_person_camera',
+      parent_link = root,
+      x = -1.5,
+      y = 0.0,
+      z = 0.5,
+      mount = none,
+      spawner_args = spawner_args)
+    -%}
+    {{ third_person_camera }}
+    {# <!--}--> #}
     {# <!--}--> #}
 
     {# ========================== other sensors ========================= #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/x500.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/x500.sdf.jinja
@@ -940,6 +940,8 @@
     }}
     {# <!--}--> #}
 
+    {# <!--}--> #}
+    
     {# third person camera {--> #}
     {%- set third_person_camera = components.third_person_camera_macro(
       camera_name = 'third_person_camera',
@@ -948,7 +950,6 @@
       spawner_args = spawner_args)
     -%}
     {{ third_person_camera }}
-    {# <!--}--> #}
     {# <!--}--> #}
 
     {# ========================== other sensors ========================= #}

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/x500.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/x500.sdf.jinja
@@ -944,9 +944,6 @@
     {%- set third_person_camera = components.third_person_camera_macro(
       camera_name = 'third_person_camera',
       parent_link = root,
-      x = -1.5,
-      y = 0.0,
-      z = 0.5,
       mount = none,
       spawner_args = spawner_args)
     -%}


### PR DESCRIPTION
- The camera is meant to give the user a third person view from a static frame attached to the drone
- The camera image is published on a ROS topic `/<UAV_NAME>/third_person_camera/image_raw`.
- The specifications are:
  - Resolution: 1920 x 1080
  - Rate: 60 Hz
- The following configurations can be provided as args to the spawner ROS service:
- `x` relative to the `/uav/fcu` frame
- `y` relative to the `/uav/fcu` frame
- `z` relative to the `/uav/fcu` frame
- `hfvo` as the horizontal FOV
- `update_rate` as the rate of the `image_raw` topic
- `noise_stddev` as the standard deviation of the zero-mean gaussian noise overlayed on the image 