### PR TITLE
Added RC mapping to airframes

### DIFF
--- a/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d/rc.mc_defaults
+++ b/ros_packages/mrs_uav_gazebo_simulation/ROMFS/px4fmu_common/init.d/rc.mc_defaults
@@ -26,6 +26,23 @@ param set-default PWM_MAIN_RATE 400
 
 param set-default GPS_UBX_DYNMODEL 6
 
+#RC control input to transmitter only (disabled joystick)
+param set-default COM_RC_IN_MODE 0
+#RC channels mapping (ATER)
+param set-default RC_MAP_ROLL 1
+param set-default RC_MAP_THROTTLE 2
+param set-default RC_MAP_PITCH 3
+param set-default RC_MAP_YAW 4
+#Switches
+param set-default RC_MAP_OFFB_SW 5
+param set-default RC_MAP_FLTMODE 6
+# MANUAL - ALTITUDE - POSITION
+param set-default COM_FLTMODE1 0
+param set-default COM_FLTMODE2 -1
+param set-default COM_FLTMODE3 -1
+param set-default COM_FLTMODE4 1
+param set-default COM_FLTMODE5 -1
+param set-default COM_FLTMODE6 2
 #
 # This is the gimbal pass mixer.
 #


### PR DESCRIPTION
Configure PX4 parameters for RC the same as on the real drones
- This feature relates to flight_trainer
- It allows using RC in simulation with the same behavior as in the real world
- Usual configuration of channels `CH1-4` - ATER (aileron, throttle, elevator, rudder), offboard `CH5`, flight-modes `CH6`, Flight modes: Manual - Altitude - Position
- It doesn't break the simulation, RC becomes active only when someone publishes data to `mavros/rc/override`


**Warning**
- Possible breaking change - `COM_RC_IN_MODE` := 0 - sets only RC to be used. PX4 automatically detects joystick/RC connected to the PC and has its own ways of use. If RC is connected to the PC, it is detected as joystick and then `mavros/rc/override` doesn't work. This way, it will ignore its joystick settings and use RC as usual.
- All previous joystick efforts, that I know of, were passing joystick to MRS system and then let MRS system to handle the rest, so it shouldn't affect anybody