### PR TITLE
ROS2 fix: passing extra_resource_paths

### DIFF
--- a/launch/mrs_drone_spawner.launch.py
+++ b/launch/mrs_drone_spawner.launch.py
@@ -19,10 +19,16 @@ def generate_launch_description():
     # Launch arguments declaration
     ld.add_action(DeclareLaunchArgument(
         'custom_config',
+        default_value = "",
+        description="Path to the custom configuration file. The path can be absolute, starting with '/' or relative to the current working directory",
+    ))
+
+    ld.add_action(DeclareLaunchArgument(
+        'default_spawner_config',
         default_value = PathJoinSubstitution([
             pkg_mrs_uav_gazebo_simulator, 'config', 'spawner_params.yaml'
         ]),
-        description="Path to the custom configuration file. The path can be absolute, starting with '/' or relative to the current working directory",
+        description='Path to the default spawner configuration file. The path can be absolute, starting with "/" or relative to the current working directory',
     ))
 
 
@@ -37,7 +43,8 @@ def generate_launch_description():
     ])
 
     log_config_args = LogInfo(msg=[
-        '[mrs_drone_spawner.launch.py] Spawner config file:', LaunchConfiguration('custom_config')
+        '\n[mrs_drone_spawner.launch.py] Custom config file: ', LaunchConfiguration('custom_config'),
+        '\n[mrs_drone_spawner.launch.py] Default config file: ', LaunchConfiguration('default_spawner_config')
     ])
     ld.add_action(log_config_args)
 
@@ -49,6 +56,7 @@ def generate_launch_description():
                 output="screen",
                 arguments=['--ros-args', '--log-level', log_level],
                 parameters=[
+                    LaunchConfiguration('default_spawner_config'),
                     LaunchConfiguration('custom_config')
                     ],
 

--- a/launch/simulation.launch.py
+++ b/launch/simulation.launch.py
@@ -28,9 +28,7 @@ def generate_launch_description():
 
     declare_spawner_config_arg = DeclareLaunchArgument(
         'spawner_config',
-        default_value = PathJoinSubstitution([
-                pkg_mrs_uav_gazebo_simulator, 'config', 'spawner_params.yaml'
-            ]),
+        default_value = "",
         description='Configuration file for the custom spawner.'
     )
 

--- a/mrs_uav_gazebo_simulator/mrs_drone_spawner.py
+++ b/mrs_uav_gazebo_simulator/mrs_drone_spawner.py
@@ -142,6 +142,7 @@ class MrsDroneSpawner(Node):
 
             self.firmware_launch_delay = float(self.get_parameter('firmware_launch_delay').value)
 
+
         except rclpy.exceptions.ParameterNotDeclaredException as e:
             self.get_logger().error(f'Could not load required param. {e}')
             raise RuntimeError(f'Could not load required param. {e}')
@@ -155,7 +156,6 @@ class MrsDroneSpawner(Node):
             # no extra resources
             extra_resource_paths = []
             pass
-        
 
         if extra_resource_paths is not None:
             for elem in extra_resource_paths:


### PR DESCRIPTION
Hi,
there is currently a bug with `mrs_drone_spawner` in ROS2 when using a custom drone configuration. The custom package defined in `spawner_config.yaml` under `extra_resource_paths` was not being passed to `mrs_drone_spawner` within the launch files. This PR fixes that issue.