### PR TITLE
update sensor position to avoid seeing sensor body

### DIFF
--- a/models/mrs_robots_description/sdf/README.md
+++ b/models/mrs_robots_description/sdf/README.md
@@ -157,7 +157,7 @@ The Gazebo camera info and point cloud topics are named by the plugin, but we ca
 {%- set ros_pointcloud_topic = root_sdf_topic + '/points' -%}           {# -- Can be modified -- #} 
 ```
 
-For a working example, we recommend checking the [realsense_top_macro](./components/camera/realsense.sdf.jinja). The table below shows the Gazebo and ROS topics for Realsense RGB-D camera:
+For a working example, we recommend checking the [realsense_rgbd_single_plugin](./components/camera/realsense_rgbd_single_plugin.sdf.jinja). The table below shows the Gazebo and ROS topics for Realsense RGB-D camera:
 <table>
   <thead>
     <tr>

--- a/models/mrs_robots_description/sdf/components/camera/realsense/realsense_depth_only.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/camera/realsense/realsense_depth_only.sdf.jinja
@@ -34,13 +34,13 @@
     {%- set pitch_offset = 0.0 -%}
     {%- set yaw_offset = 0.0 -%}
 
-    <!-- Realsense front {-->
+    <!-- Realsense {{ camera_name }} {-->
     <link name="{{ camera_link_name }}">
       <pose relative_to="{{ parent_link }}">{{ x }} {{ y }} {{ z }} {{ roll }} {{ pitch }} {{ yaw }}</pose>
       {{ generic.zero_inertial_macro() }}
       <!-- visuals {-->
       <visual name="body_visual">
-        <pose>0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
+        <pose>-0.026 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
         <geometry>
           <mesh>
             <uri>model://mrs_robots_description/meshes/sensors/realsense_body.stl</uri>
@@ -55,7 +55,7 @@
         </material>
       </visual>
       <visual name="glass_visual">
-        <pose>0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
+        <pose>-0.026 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
         <geometry>
           <mesh>
             <uri>model://mrs_robots_description/meshes/sensors/realsense_glass.stl</uri>
@@ -86,7 +86,7 @@
         image_width = 752,
         image_height = 480,
         min_distance = 0.1,
-        max_distance = 80,
+        max_distance = 12,
         noise_mean = 0.0,
         noise_stddev = spawner_args[spawner_keyword]['noise'],
         x_offset = x_offset,
@@ -100,6 +100,7 @@
     </link>
 
     <link name="{{ camera_gz_frame_id }}">
+      {{ generic.zero_inertial_macro() }}
       <pose relative_to="{{ camera_link_name }}">0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
     </link>
 

--- a/models/mrs_robots_description/sdf/components/camera/realsense/realsense_rgb_plus_depth.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/camera/realsense/realsense_rgb_plus_depth.sdf.jinja
@@ -41,13 +41,13 @@
     {%- set pitch_offset = 0.0 -%}
     {%- set yaw_offset = 0.0 -%}
 
-    <!-- Realsense front {-->
+    <!-- Realsense {{ camera_name }} {-->
     <link name="{{ camera_link_name }}">
       <pose relative_to="{{ parent_link }}">{{ x }} {{ y }} {{ z }} {{ roll }} {{ pitch }} {{ yaw }}</pose>
       {{ generic.zero_inertial_macro() }}
       <!-- visuals {-->
       <visual name="body_visual">
-        <pose>0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
+        <pose>-0.026 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
         <geometry>
           <mesh>
             <uri>model://mrs_robots_description/meshes/sensors/realsense_body.stl</uri>
@@ -62,7 +62,7 @@
         </material>
       </visual>
       <visual name="glass_visual">
-        <pose>0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
+        <pose>-0.026 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
         <geometry>
           <mesh>
             <uri>model://mrs_robots_description/meshes/sensors/realsense_glass.stl</uri>
@@ -115,7 +115,7 @@
         image_width = 752,
         image_height = 480,
         min_distance = 0.1,
-        max_distance = 80,
+        max_distance = 12,
         noise_mean = 0.0,
         noise_stddev = spawner_args[spawner_keyword]['noise'],
         x_offset = x_offset,
@@ -134,6 +134,7 @@
     </joint>
 
     <link name="{{ camera_color_gz_frame_id }}">
+      {{ generic.zero_inertial_macro() }}
       <pose relative_to="{{ camera_link_name }}">0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
     </link>
     <joint name="{{ camera_color_gz_frame_id }}_joint" type="fixed">
@@ -142,6 +143,7 @@
     </joint>
 
     <link name="{{ camera_depth_gz_frame_id }}">
+      {{ generic.zero_inertial_macro() }}
       <pose relative_to="{{ camera_link_name }}">0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
     </link>
     <joint name="{{ camera_depth_gz_frame_id }}_joint" type="fixed">

--- a/models/mrs_robots_description/sdf/components/camera/realsense/realsense_rgbd_single_plugin.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/camera/realsense/realsense_rgbd_single_plugin.sdf.jinja
@@ -2,10 +2,10 @@
 {%- import 'mrs_robots_description/sdf/components/generic_components.sdf.jinja' as generic -%}
 
 {# ============================= Realsense Camera Macro ============================ #}
-{# realsense_top_macro {--> #}
-{%- macro realsense_top_macro(camera_name, parent_link, x, y, z, roll, pitch, yaw, mount, spawner_args) -%}
+{# realsense_rgbd_single_plugin_macro {--> #}
+{%- macro realsense_rgbd_single_plugin_macro(camera_name, parent_link, x, y, z, roll, pitch, yaw, mount, spawner_args) -%}
 
-  {%- set spawner_keyword = 'enable-realsense-top' -%}
+  {%- set spawner_keyword = 'enable-realsense-rgbd-single-plugin' -%}
   {%- set spawner_description = 'Add Intel Realsense D435 depth camera to the vehicle [1280x720 @ 30hz], pointed forward, placed on an aluminum frame above the body' -%}
   {%- set spawner_default_args = {'update_rate': 30, 'noise': 0.0} -%}
 
@@ -35,13 +35,13 @@
     {%- set pitch_offset = 0.0 -%}
     {%- set yaw_offset = 0.0 -%}
 
-    <!-- Realsense front {-->
+    <!-- Realsense {{ camera_name }} {-->
     <link name="{{ camera_link_name }}">
       <pose relative_to="{{ parent_link }}">{{ x }} {{ y }} {{ z }} {{ roll }} {{ pitch }} {{ yaw }}</pose>
       {{ generic.zero_inertial_macro() }}
       <!-- visuals {-->
       <visual name="body_visual">
-        <pose>0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
+        <pose>-0.026 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
         <geometry>
           <mesh>
             <uri>model://mrs_robots_description/meshes/sensors/realsense_body.stl</uri>
@@ -56,7 +56,7 @@
         </material>
       </visual>
       <visual name="glass_visual">
-        <pose>0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
+        <pose>-0.026 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
         <geometry>
           <mesh>
             <uri>model://mrs_robots_description/meshes/sensors/realsense_glass.stl</uri>
@@ -88,7 +88,7 @@
         image_width = 752,
         image_height = 480,
         min_distance = 0.1,
-        max_distance = 80,
+        max_distance = 12,
         noise_mean = 0.0,
         noise_stddev = spawner_args[spawner_keyword]['noise'],
         x_offset = x_offset,
@@ -107,6 +107,7 @@
     </joint>
 
     <link name="{{ camera_gz_frame_id }}">
+      {{ generic.zero_inertial_macro() }}
       <pose relative_to="{{ camera_link_name }}">0 0 0 {{ -math.radians(90) }} 0 {{ -math.radians(90) }}</pose>
     </link>
     <joint name="{{ camera_gz_frame_id }}_joint" type="fixed">

--- a/models/mrs_robots_description/sdf/components/component_snippets.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/component_snippets.sdf.jinja
@@ -242,9 +242,9 @@ limitations under the License.
 {# Note: All of these cameras have misaligned point clouds. We are waiting for a fix. #}
 
 {# ==== Realsense camera ==== #}
-{%- import "mrs_robots_description/sdf/components/camera/realsense/realsense_top.sdf.jinja" as realsense_camera_top -%}
-{%- macro realsense_top_macro(camera_name, parent_link, x, y, z, roll, pitch, yaw, mount, spawner_args) -%}
-  {{ realsense_camera_top.realsense_top_macro(camera_name, parent_link, x, y, z, roll, pitch, yaw, mount, spawner_args) }}
+{%- import "mrs_robots_description/sdf/components/camera/realsense/realsense_rgbd_single_plugin.sdf.jinja" as realsense_camera_top -%}
+{%- macro realsense_rgbd_single_plugin_macro(camera_name, parent_link, x, y, z, roll, pitch, yaw, mount, spawner_args) -%}
+  {{ realsense_camera_top.realsense_rgbd_single_plugin_macro(camera_name, parent_link, x, y, z, roll, pitch, yaw, mount, spawner_args) }}
 {%- endmacro -%}
 
 {%- import "mrs_robots_description/sdf/components/camera/realsense/realsense_rgb_plus_depth.sdf.jinja" as realsense_camera_rgb_plus_d -%}

--- a/models/mrs_robots_description/sdf/components/generic_components.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/generic_components.sdf.jinja
@@ -876,7 +876,7 @@ limitations under the License.
   <sensor name="{{ camera_name }}/depth" type="depth_camera">
     <pose>{{ x_offset }} {{ y_offset }} {{ z_offset }} {{ roll_offset }} {{ pitch_offset }} {{ yaw_offset }}</pose>
     <always_on>true</always_on>
-    <visualize>true</visualize>
+    <visualize>false</visualize>
     <gz_frame_id>{{ camera_gz_frame_id }}</gz_frame_id>
     <update_rate>{{ frame_rate }}</update_rate>
 
@@ -893,6 +893,7 @@ limitations under the License.
         <width> {{ image_width }} </width>
         <height>{{ image_height }}</height>
         <format>R_FLOAT32</format>
+        <anti_aliasing>0</anti_aliasing>
       </image>
       <clip>
         <near>{{ min_distance }}</near>

--- a/models/mrs_robots_description/sdf/drones/x500.sdf.jinja
+++ b/models/mrs_robots_description/sdf/drones/x500.sdf.jinja
@@ -799,6 +799,26 @@
 
     {# <!--}--> #}
 
+    {# Realsense placements {--> #}
+
+    {# realsense front {--> #}
+    {%- set realsense_front = components.realsense_rgb_plus_depth_macro(
+      camera_name = 'front_rgbd',
+      parent_link = root,
+      x = 0.118,
+      y = 0.0,
+      z = 0.016,
+      roll = 0,
+      pitch = 0,
+      yaw = 0,
+      mount = realsense_mount,
+      spawner_args = spawner_args)
+    -%}
+    {{ realsense_front }}
+    {# <!--}--> #}
+
+    {# <!--}--> #}
+
     {# ====================== conditional components ==================== #}
 
     {# lidar mount / gps antenna visuals {--> #}


### PR DESCRIPTION
Note: Depth image is based on camera Z-buffer
Placing the gazebo sensor inside the body of the device will cause it to see the inner walls
This happens despite camera near clipping settings, and the model being visual-only without collisions

-> the gazebo sensor needs to be physically outside of the model of the sensor

I moved the visuals back by a little (-0.026 in X), so the offset needs to be compensated when mounting the sensor to a drone (add 0.026 to the component's X position).

