### PR TITLE
Workaround to the problem of spawning a camera and a 3D LiDAR using GPU

### DIFF
--- a/ros_packages/.gitman.yml
+++ b/ros_packages/.gitman.yml
@@ -2,7 +2,7 @@ location: .gitman
 sources:
   - repo: https://github.com/ctu-mrs/mrs_gazebo_common_resources.git
     name: mrs_gazebo_common_resources
-    rev: master
+    rev: depth-3dlidar-fix
     type: git
     params:
     sparse_paths:

--- a/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/generic_components.sdf.jinja
+++ b/ros_packages/mrs_uav_gazebo_simulation/models/mrs_robots_description/sdf/generic_components.sdf.jinja
@@ -1378,7 +1378,7 @@ limitations under the License.
         </image>
         <clip>
           <near>0.3</near>
-          <far>12</far>
+          <far>121</far>
         </clip>
         <noise>
           <type>gaussian</type>


### PR DESCRIPTION
Workaround for [issue 27 in mrs_gazebo_common_resources](https://github.com/ctu-mrs/mrs_gazebo_common_resources/issues/27). Must be used together with the `depth-3dlidar-fix` branch there (see the related PR). Tested, works, but may have a performance impact due to the longer rendering distance of the depth camera (although I didn't notice one on my PC)...