### PR TITLE
feat: publish correct TF frame for Garmin rangefinder sensors

### DIFF
--- a/config/spawner_params.yaml
+++ b/config/spawner_params.yaml
@@ -18,4 +18,4 @@ mrs_drone_spawner:
 
     tf_static_publisher:
       base_frame: "fcu"
-      ignored_sensor_frames: ["air_pressure_sensor", "magnetometer_sensor", "navsat_sensor", "imu_sensor", "lidar"] #lidar is reserved for PX4 Garmin
+      ignored_sensor_frames: ["air_pressure_sensor", "magnetometer_sensor", "navsat_sensor", "imu_sensor"]

--- a/models/mrs_robots_description/sdf/components/generic_components.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/generic_components.sdf.jinja
@@ -884,9 +884,9 @@ limitations under the License.
 {# <!--}--> #}
 
 {# rangefinder_sensor_macro {--> #}
-{%- macro rangefinder_sensor_macro(name, update_rate, sensor_link_name, parent_link_name, samples, min_distance, max_distance, resolution, x, y, z, roll, pitch, yaw) -%}
+{%- macro rangefinder_sensor_macro(name, update_rate, samples, min_distance, max_distance, resolution, sensor_x, sensor_y, sensor_z, sensor_roll, sensor_pitch, sensor_yaw) -%}
   <sensor name="{{ name }}" type="gpu_lidar">
-  <pose relative_to="{{ parent_link_name }}">{{ x }} {{ y }} {{ z }} {{ roll }} {{ pitch }} {{ yaw }}</pose>
+  <pose>{{ sensor_x }} {{ sensor_y }} {{ sensor_z }} {{ sensor_roll }} {{ sensor_pitch }} {{ sensor_yaw }}</pose>
   <update_rate>{{ update_rate }}</update_rate>
   <lidar>
     <scan>

--- a/models/mrs_robots_description/sdf/components/rangefinder/garmin/garmin_down_external.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/rangefinder/garmin/garmin_down_external.sdf.jinja
@@ -37,18 +37,16 @@
       {{ generic.rangefinder_sensor_macro(
         name = sensor_name,
         update_rate = spawner_args[spawner_keyword]['update_rate'],
-        sensor_link_name = sensor_name ~ "_sensor_link",
-        parent_link_name = parent_link,
         samples = 3,
         min_distance = spawner_args[spawner_keyword]['min_range'],
         max_distance = spawner_args[spawner_keyword]['max_range'],
         resolution = 0.005,
-        x = x,
-        y = y,
-        z = z,
-        roll = roll,
-        pitch = pitch,
-        yaw = yaw)
+        sensor_x = 0,
+        sensor_y = 0,
+        sensor_z = 0,
+        sensor_roll = 0,
+        sensor_pitch = 0,
+        sensor_yaw = 0)
       }}
 
     </link>

--- a/models/mrs_robots_description/sdf/components/rangefinder/garmin/garmin_down_pixhawk.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/rangefinder/garmin/garmin_down_pixhawk.sdf.jinja
@@ -37,18 +37,16 @@
       {{ generic.rangefinder_sensor_macro(
         name = sensor_name,
         update_rate = spawner_args[spawner_keyword]['update_rate'],
-        sensor_link_name = sensor_name ~ "_sensor_link",
-        parent_link_name = parent_link,
         samples = 3,
         min_distance = spawner_args[spawner_keyword]['min_range'],
         max_distance = spawner_args[spawner_keyword]['max_range'],
         resolution = 0.005,
-        x = x,
-        y = y,
-        z = z,
-        roll = roll,
-        pitch = pitch,
-        yaw = yaw)
+        sensor_x = 0,
+        sensor_y = 0,
+        sensor_z = 0,
+        sensor_roll = 0,
+        sensor_pitch = 0,
+        sensor_yaw = 0)
       }}
 
     </link>

--- a/models/mrs_robots_description/sdf/components/rangefinder/garmin/garmin_up_external.sdf.jinja
+++ b/models/mrs_robots_description/sdf/components/rangefinder/garmin/garmin_up_external.sdf.jinja
@@ -37,18 +37,16 @@
       {{ generic.rangefinder_sensor_macro(
         name = sensor_name,
         update_rate = spawner_args[spawner_keyword]['update_rate'],
-        sensor_link_name = sensor_name ~ "_sensor_link",
-        parent_link_name = parent_link,
         samples = 3,
         min_distance = spawner_args[spawner_keyword]['min_range'],
         max_distance = spawner_args[spawner_keyword]['max_range'],
         resolution = 0.005,
-        x = x,
-        y = y,
-        z = z,
-        roll = roll,
-        pitch = pitch,
-        yaw = yaw)
+        sensor_x = 0,
+        sensor_y = 0,
+        sensor_z = 0,
+        sensor_roll = 0,
+        sensor_pitch = 0,
+        sensor_yaw = 0)
       }}
 
     </link>

--- a/mrs_uav_gazebo_simulator/core/sdf_to_tf_publisher.py
+++ b/mrs_uav_gazebo_simulator/core/sdf_to_tf_publisher.py
@@ -59,11 +59,20 @@ class SdfTfPublisherSingleton(metaclass=SingletonMeta):
     # #{ _detect_sensors_transformations(self, links_to_sensors)
     def _detect_sensors_transformations(self, links_to_sensors):
         for link_name, data in links_to_sensors.items():
+            sensors = data[LinkToSensorData.SENSORS]
+
+            # A link whose only sensor sits at an identity offset (and has no optical frame) has no
+            # meaningful housing frame of its own (e.g. a bare rangefinder or 2D lidar). Publish one
+            # direct base_frame -> sensor transform instead of a redundant base_frame -> link -> sensor chain.
+            if self._is_standalone_sensor_link(data):
+                self._register_direct_sensor_transform(sensor_data=sensors[0],
+                                                       pose_str=data[LinkToSensorData.LINK_POSE_STR])
+                continue
+
             if not self._register_sensor_link_transform(link_name=link_name, data=data):
                 self._ros_node.get_logger().info(
                     f"[Sdf2Tf_Publisher] Sensor link {link_name} has no pose, cannot create its tf publisher.")
                 continue
-            sensors = data[LinkToSensorData.SENSORS]
             for sensor in sensors:
                 self._register_sensor_offset_transform(sensor_data=sensor, parent_frame=link_name)
 
@@ -72,20 +81,53 @@ class SdfTfPublisherSingleton(metaclass=SingletonMeta):
 
     # #}
 
+    # #{ _is_standalone_sensor_link(self, data) -> bool
+    def _is_standalone_sensor_link(self, data) -> bool:
+        sensors = data[LinkToSensorData.SENSORS]
+        if len(sensors) != 1:
+            return False
+        sensor = sensors[0]
+        if self._has_optical_frame(sensor[SensorLinkData.OPTICAL_FRAME_POSE_STR]):
+            return False
+        return self._is_identity_pose(sensor[SensorLinkData.SENSOR_OFFSET_POSE_STR])
+
+    # #}
+
+    # #{ _is_identity_pose(self, pose_str) -> bool
+    def _is_identity_pose(self, pose_str) -> bool:
+        if pose_str is None or pose_str == "":
+            return True
+        return bool(np.all(self._str_to_pose(pose_str) == 0))
+
+    # #}
+
     # #{ _register_sensor_link_transform(self, link_name, data)
     def _register_sensor_link_transform(self, link_name, data):
-        # Publish transform of the sensor link with respect to the world frame
-        pose_World_SensorLink_str = data[LinkToSensorData.LINK_POSE_STR]
-        if pose_World_SensorLink_str is None or (pose_World_SensorLink_str == ""):
+        # Publish transform of the sensor link with respect to the base frame
+        pose_Base_SensorLink_str = data[LinkToSensorData.LINK_POSE_STR]
+        if pose_Base_SensorLink_str is None or (pose_Base_SensorLink_str == ""):
             return False
-        T_W_SensorLink = self._get_transform_from_string_pose(pose_World_SensorLink_str)
+        T_Base_SensorLink = self._get_transform_from_string_pose(pose_Base_SensorLink_str)
 
         self._transformations.append({
             TfData.CHILD_FRAME: self._append_namespace(link_name),
             TfData.PARENT_FRAME: self._append_namespace(self._base_frame),
-            TfData.TF_MATRIX: T_W_SensorLink
+            TfData.TF_MATRIX: T_Base_SensorLink
         })
         return True
+
+    # #}
+
+    # #{ _register_direct_sensor_transform(self, sensor_data, pose_str)
+    def _register_direct_sensor_transform(self, sensor_data, pose_str):
+        # Publish transform of a standalone sensor directly with respect to the base frame
+        T_Base_Sensor = self._get_transform_from_string_pose(pose_str)
+
+        self._transformations.append({
+            TfData.CHILD_FRAME: self._append_namespace(sensor_data[SensorLinkData.SENSOR_NAME]),
+            TfData.PARENT_FRAME: self._append_namespace(self._base_frame),
+            TfData.TF_MATRIX: T_Base_Sensor
+        })
 
     # #}
 
@@ -180,6 +222,10 @@ class SdfTfPublisherSingleton(metaclass=SingletonMeta):
                 sensors_within_link = []
                 for sensor in sensors:
                     sensor_name = sensor.get("name")
+                    # PX4's gazebo_mavlink_interface requires the Garmin rangefinder's SDF sensor to be
+                    # literally named "lidar"; use the more descriptive name for the published TF frame.
+                    if sensor_name == "lidar":
+                        sensor_name = "garmin"
                     sensor_offset_pose_str = sensor.findtext('pose')
                     gz_frame_name = sensor.findtext("gz_frame_id")
 
@@ -266,14 +312,14 @@ class SdfTfPublisherSingleton(metaclass=SingletonMeta):
 
     # #}
 
-    # #{ _matrix_to_tf_pose(self, T_W_Sensor: np.ndarray) -> Transform
-    def _matrix_to_tf_pose(self, T_W_Sensor: np.ndarray) -> Transform:
+    # #{ _matrix_to_tf_pose(self, T_matrix: np.ndarray) -> Transform
+    def _matrix_to_tf_pose(self, T_matrix: np.ndarray) -> Transform:
         pose = Transform()
-        pose.translation.x = T_W_Sensor[0, 3]
-        pose.translation.y = T_W_Sensor[1, 3]
-        pose.translation.z = T_W_Sensor[2, 3]
+        pose.translation.x = T_matrix[0, 3]
+        pose.translation.y = T_matrix[1, 3]
+        pose.translation.z = T_matrix[2, 3]
 
-        quat = R.from_matrix(T_W_Sensor[:3, :3]).as_quat()
+        quat = R.from_matrix(T_matrix[:3, :3]).as_quat()
         pose.rotation.x = quat[0]
         pose.rotation.y = quat[1]
         pose.rotation.z = quat[2]


### PR DESCRIPTION
## Summary
- **What changed**: 
Fixed TF publishing for standalone sensors (e.g. Garmin rangefinders). `sdf_to_tf_publisher.py` now detects links that hold a single, offset-less, non-optical sensor and publishes a direct `base_frame -> sensor` transform instead of a redundant `base_frame -> link -> sensor` chain. The published frame for the Garmin rangefinder is renamed from `lidar` to `garmin` (the SDF sensor itself must stay named `lidar` for PX4's `gazebo_mavlink_interface` to pick it up). The `rangefinder_sensor_macro` was reworked so the sensor's pose lives on the sensor itself (`sensor_x/y/z/roll/pitch/yaw`, defaulting to identity) rather than being pushed onto the parent link, and the Garmin rangefinder templates were updated to match. `ignored_sensor_frames` in `spawner_params.yaml` no longer needs the `lidar` special-case since it's now handled directly by the standalone-sensor logic.
- **Why**: 
The old code always chained `link -> sensor`, which for a bare rangefinder link produced a spurious intermediate frame and, combined with PX4's hard requirement that the SDF sensor be named `lidar`, an incorrectly named published TF frame (`lidar` instead of a MRS system required `garmin`).
- **Notes for reviewers**: 
The "standalone sensor" detection (`_is_standalone_sensor_link`) only special-cases links with exactly one sensor that has an identity offset pose and no optical frame — links with multiple sensors or a genuine housing offset still go through the original link-then-sensor TF chain, so this should be backward compatible for cameras/lidars with real offsets.

## Impact
- **Affected areas**: 
Gazebo TF publishing (`sdf_to_tf_publisher.py`), Garmin rangefinder SDF templates (`garmin_down_external`, `garmin_down_pixhawk`, `garmin_up_external`), generic rangefinder macro, spawner default params
- **Breaking changes**: 
Yes — garmin TF frame is now published automatically. mrs_uav_px4_api needs to be updated to not publish tf by itself 

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [ ] Tests updated if needed
    * [x] Tested in simulation
    * [ ] Tested on real HW

- **How to repeat tests**:
```bash
launch mrs_uav_gazebo_simulator with rangefinder